### PR TITLE
fix: prevent reasoning_content during content stream

### DIFF
--- a/parser/hcx_reasoner.py
+++ b/parser/hcx_reasoner.py
@@ -105,12 +105,9 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
                 else:
                     self.buffer_string = ''
                     return DeltaMessage(reasoning_content=buffered_content, content=delta_text)
-                
+
         if self.check_is_part_of_special_string():
-            if self.is_reasoning_end(delta_token_ids):
-                return DeltaMessage(reasoning_content=self.buffer_string)
-            else:
-                return None
+            return None
         else:
             delta_text = self.buffer_string
             self.buffer_string = ''


### PR DESCRIPTION
This PR fixes a bug where, after the reasoning content finished and normal content tokens were streaming, encountering the final `<|im_end|>` token caused the parser to briefly emit an extra `reasoning_content` chunk before returning to content and completing the stream.

The fix ensures that no additional `reasoning_content` is emitted, even when `<|im_end|>` appears at the tail of the stream.