### PR TITLE
Fix `is_reasoning_end` not detecting end tokens with structured output

### DIFF
--- a/parser/hcx_reasoner.py
+++ b/parser/hcx_reasoner.py
@@ -22,7 +22,7 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
         super().__init__(tokenizer)
         self.think_start_token = "/think\n"
-        self.think_end_token = "<|im_end|>\n<|im_start|>assistant"
+        self.think_end_string_base = "<|im_end|>\n<|im_start|>assistant"
 
         # for streaming
         self.end_token_id = self.vocab.get("<|im_end|>")
@@ -30,9 +30,16 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
         self.function_call_role = ' -> tool/function_call\n'
         self.no_reasoning_content = False
 
+        # for is_reasoning_end check
+        self.exact_think_end_strings = [
+            self.think_end_string_base + "\n",
+            self.think_end_string_base + self.function_call_role
+        ]
+        self.think_end_tokens = [tokenizer.encode(think_end_string) for think_end_string in self.exact_think_end_strings]
+
         # attributes for streaming parser mixin
         self.buffer_string = ''
-        self.special_strings = ['/think\n', '<|im_end|>\n<|im_start|>assistant', self.function_call_role]
+        self.special_strings = [self.think_start_token, self.think_end_string_base, self.function_call_role]
         self.escaped_special_strings = [re.escape(ss) for ss in self.special_strings]
 
 
@@ -40,26 +47,33 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
             self, model_output: str, request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
         chat_template_kwargs = request.chat_template_kwargs or {}
-        if chat_template_kwargs.get('skip_reasoning', False):
-            return None, model_output
 
         is_reasoning = False
 
         if chat_template_kwargs.get('force_reasoning', False):
             is_reasoning = True
+        # if both are True, prioritize force_reasoning
+        elif chat_template_kwargs.get('skip_reasoning', False):
+            return None, model_output
 
         if model_output.startswith(self.think_start_token):
             is_reasoning = True
             model_output_parts = model_output.partition(self.think_start_token)
             model_output = model_output_parts[2]
-        
-        if self.think_end_token not in model_output:
+
+        if self.think_end_string_base not in model_output:
             if is_reasoning:
                 return model_output, None
             else:
-                return None, model_output
+                # auto tool choice case
+                if request.tool_choice == "auto" or request.tool_choice is None:
+                    if model_output.startswith('\n'):
+                        model_output = model_output[1:]
+                    return None, model_output
+                else: # others: 'required', 'named tool call'
+                    return None, model_output.replace(self.function_call_role, '')
 
-        reasoning_content, _, content = model_output.partition(self.think_end_token)
+        reasoning_content, _, content = model_output.partition(self.think_end_string_base)
 
         final_content = content or None
 
@@ -75,7 +89,7 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
     ) -> Union[DeltaMessage, None]:
-        if current_token_ids[0] == self.non_reasoning_mode_start_token:
+        if current_token_ids and current_token_ids[0] == self.non_reasoning_mode_start_token:
             self.no_reasoning_content = True
             
         if len(current_text) == 0:
@@ -112,7 +126,7 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
             delta_text = self.buffer_string
             self.buffer_string = ''
 
-        if self.think_end_token in current_text:
+        if self.think_end_string_base in current_text:
             return DeltaMessage(content=delta_text)
         else:
             return DeltaMessage(reasoning_content=delta_text)
@@ -120,7 +134,13 @@ class HcxReasoningParser(ReasoningParser, HcxStreamingParserFunctionsMixin):
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         if len(input_ids) > 1:
+            for think_end_tokens in self.think_end_tokens:
+                think_end_len = len(think_end_tokens)
+                if len(input_ids) >= think_end_len and input_ids[-think_end_len:] == think_end_tokens:
+                    return True
+
             return False
+
         return self.no_reasoning_content or self.end_token_id in input_ids
 
 


### PR DESCRIPTION
## Summary
* Fix `is_reasoning_end` not detecting end tokens when structured output and reasoning are used together
* Add support for multiple reasoning end patterns including function call suffix
* Improve tool_choice handling for non-reasoning mode outputs

## Problem
* When using structured output (`tool_choice`: `required` or `named tool`) together with reasoning mode, the `is_reasoning_end` function failed to detect the end of reasoning content. This was because the reasoning end sequence varies depending on whether it's followed by normal content (`\n`) or a function call (`-> tool/function_call\n`).

## Changes
`is_reasoning_end` fix (core issue)

* Added exact_think_end_strings to handle both patterns:
    * `<|im_end|>\n<|im_start|>assistant\n` (normal content)
    * `<|im_end|>\n<|im_start|>assistant -> tool/function_call\n` (function call)
* Updated `is_reasoning_end` to check if `input_ids` ends with any of the `think_end_tokens`

### Other improvements
* Prioritize `force_reasoning` over `skip_reasoning` when both are set
* Add defensive check for empty `current_token_ids` in streaming parser